### PR TITLE
Add implementation for list pokemon

### DIFF
--- a/app/src/main/java/xyz/mcnallydawes/pokedex/ListPokemon.kt
+++ b/app/src/main/java/xyz/mcnallydawes/pokedex/ListPokemon.kt
@@ -1,0 +1,16 @@
+package xyz.mcnallydawes.pokedex
+
+import xyz.mcnallydawes.pokedex.boundary.ListPokemonInteractor
+import xyz.mcnallydawes.pokedex.request.ListPokemonRequest
+import xyz.mcnallydawes.pokedex.response.ListPokemonResponse
+import xyz.mcnallydawes.pokedex.source.PokemonSource
+
+class ListPokemon(private val pokemonSource: PokemonSource) : ListPokemonInteractor {
+
+    override fun execute(request: ListPokemonRequest): Try<ListPokemonResponse> =
+            pokemonSource.getAll()
+                    .map { pokemon ->
+                        ListPokemonResponse(pokemon)
+                    }
+
+}

--- a/app/src/test/java/xyz/mcnallydawes/pokedex/ListPokemonTest.kt
+++ b/app/src/test/java/xyz/mcnallydawes/pokedex/ListPokemonTest.kt
@@ -1,0 +1,50 @@
+package xyz.mcnallydawes.pokedex
+
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.whenever
+import junit.framework.TestCase.assertEquals
+import org.junit.Before
+import org.junit.Test
+import xyz.mcnallydawes.pokedex.boundary.ListPokemonInteractor
+import xyz.mcnallydawes.pokedex.entity.Grass
+import xyz.mcnallydawes.pokedex.entity.Pokemon
+import xyz.mcnallydawes.pokedex.request.ListPokemonRequest
+import xyz.mcnallydawes.pokedex.source.PokemonSource
+
+class ListPokemonTest {
+
+    private lateinit var listPokemon: ListPokemonInteractor
+
+    private val pokemonSource: PokemonSource = mock()
+
+    @Before
+    fun setUp() {
+        listPokemon = ListPokemon(pokemonSource)
+    }
+
+    @Test
+    fun `execute fails when pokemon source fails`() {
+        val failure = Failure<List<Pokemon>>(Throwable("Random throwable"))
+        doReturn(failure).whenever(pokemonSource).getAll()
+        val response = listPokemon.execute(ListPokemonRequest())
+        assertEquals(response, failure)
+    }
+
+    @Test
+    fun `execute returns empty list when pokemon source is empty`() {
+        val success = Success(ArrayList<Pokemon>())
+        doReturn(success).whenever(pokemonSource).getAll()
+        val response = listPokemon.execute(ListPokemonRequest()) as Success
+        assertEquals(response.value.pokemon, success.value)
+    }
+
+    @Test
+    fun `execute returns correct list`() {
+        val success = Success(listOf(Pokemon("1", "Bulbasaur", setOf(Grass))))
+        doReturn(success).whenever(pokemonSource).getAll()
+        val response = listPokemon.execute(ListPokemonRequest()) as Success
+        assertEquals(response.value.pokemon, success.value)
+    }
+
+}

--- a/domain/src/main/java/xyz/mcnallydawes/pokedex/boundary/ListPokemonInteractor.kt
+++ b/domain/src/main/java/xyz/mcnallydawes/pokedex/boundary/ListPokemonInteractor.kt
@@ -3,4 +3,4 @@ package xyz.mcnallydawes.pokedex.boundary
 import xyz.mcnallydawes.pokedex.request.ListPokemonRequest
 import xyz.mcnallydawes.pokedex.response.ListPokemonResponse
 
-interface ListPokemon : Interactor<ListPokemonRequest, ListPokemonResponse>
+interface ListPokemonInteractor : Interactor<ListPokemonRequest, ListPokemonResponse>


### PR DESCRIPTION
This commit adds the app's implementation for ListPokemonInteractor
which was renamed from the original domain ListPokemon interface.